### PR TITLE
Create close-old-issues.yml

### DIFF
--- a/.github/workflows/close-old-issues.yml
+++ b/.github/workflows/close-old-issues.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 30
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated management of inactive issues.
  * Runs daily at 01:30 to evaluate recent activity.
  * Marks issues as stale after 60 days of inactivity, applies a “stale” label, and posts a notification.
  * Automatically closes issues 30 days after being marked stale.
  * Pull requests are excluded from staleness and automatic closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->